### PR TITLE
Fix setvartable payload array handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,16 +164,18 @@ Manually triggers an immediate PLC read cycle
 #### `setvartable`
 Dynamically updates the variable table during runtime. Supports both array and text formats.
 
-**Array Format (Legacy):**
+**Array Format (msg.vartable or msg.payload):**
 ```json
 {
   "function": "setvartable",
-  "vartable": [
+  "payload": [
     {"name": "temperature", "addr": "DB1,REAL0"},
     {"name": "pressure", "addr": "DB1,REAL4"}
   ]
 }
 ```
+
+> 💡 Prefer `msg.payload` for new flows. `msg.vartable` remains supported for backward compatibility.
 
 **Text Format (New in v4.2.0):**
 ```json
@@ -189,6 +191,7 @@ Dynamically updates the variable table during runtime. Supports both array and t
 - Line breaks: Use `\n` or actual newlines
 - Whitespace: Automatically trimmed
 - Empty lines: Ignored
+- Works alongside array input on `msg.payload` or `msg.vartable`
 - Perfect for copy-paste from Excel/CSV files
 
 #### `ssl`
@@ -227,7 +230,7 @@ The `setvartable` function provides powerful runtime reconfiguration capabilitie
 
 ### How It Works
 
-1. **Variable Table Update**: The S7 Control node accepts a new variable table via `msg.vartable` (array format) or `msg.payload` (text format)
+1. **Variable Table Update**: The S7 Control node accepts a new variable table via `msg.payload` (array or text) or `msg.vartable` (array)
 2. **Automatic Propagation**: All S7 In nodes connected to the same endpoint automatically adapt to the new variables
 3. **Event-Driven Synchronization**: Uses the internal `__VARS_CHANGED__` event system to notify all nodes
 4. **Seamless Operation**: No interruption to existing flows or data processing

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,8 @@
+Version: 4.2.1 (Unreleased)
+------------
+ - **FIX**: Allow `setvartable` control messages to accept arrays via `msg.payload`
+ - **COMPATIBILITY**: Continue supporting `msg.vartable` arrays and text parsing without breaking existing flows
+
 Version: 4.2.0
 ------------
  - **FEATURE**: Added built-in text parsing to S7 Control setvartable function

--- a/docs/EXAMPLE-USAGE.md
+++ b/docs/EXAMPLE-USAGE.md
@@ -148,10 +148,11 @@ The S7 nodes use a specific address format:
 // Input message
 {
     "function": "setvartable",
-    "vartable": [
+    "payload": [
         {"name": "new_var1", "addr": "DB2,INT0"},
         {"name": "new_var2", "addr": "DB2,REAL4"}
     ]
+    // Alternatively provide the same array via msg.vartable
 }
 ```
 

--- a/docs/issue-1-plan.md
+++ b/docs/issue-1-plan.md
@@ -1,0 +1,9 @@
+# Plan for Issue #1
+
+This branch (`issue-1-s7`) was created to address [Issue #1](https://github.com/oriolrius/node-red-contrib-s7/issues/1).
+
+## Status
+- [x] Reviewed Issue #1 details and reproduced the incompatibility with `msg.payload` arrays.
+- [x] Implemented compatibility fix and updated documentation.
+- [x] Added regression tests for the new parser utility.
+

--- a/red/s7.html
+++ b/red/s7.html
@@ -1445,10 +1445,10 @@ Result:
 		<dd>
 			<strong>Purpose:</strong> Replace the entire variable table at runtime<br>
 			<strong>Input Options:</strong>
-			<ul>
-				<li><strong>Array format:</strong> <code>msg.vartable</code> = <code>[{name: "var1", addr: "DB1,X0.0"}]</code></li>
-				<li><strong>Text format (NEW):</strong> <code>msg.payload</code> = <code>"DB1,X0.0;motor_running\nDB1,INT2;temperature"</code></li>
-			</ul>
+                        <ul>
+                                <li><strong>Array format:</strong> Provide the array on <code>msg.payload</code> or <code>msg.vartable</code> &ndash; e.g. <code>[{name: "var1", addr: "DB1,X0.0"}]</code></li>
+                                <li><strong>Text format (NEW):</strong> <code>msg.payload</code> = <code>"DB1,X0.0;motor_running\nDB1,INT2;temperature"</code></li>
+                        </ul>
 			<strong>Text Format:</strong> One variable per line, format: <code>address;name</code><br>
 			<strong>Use case:</strong> Recipe-based variable sets, conditional monitoring, easy copy-paste from spreadsheets
 		</dd>
@@ -1644,7 +1644,7 @@ DB1,REAL4;speed_setpoint</pre>
 		<tr style="background-color: #f0f0f0;"><th style="border: 1px solid #ddd; padding: 4px;">Function</th><th style="border: 1px solid #ddd; padding: 4px;">Required Input</th><th style="border: 1px solid #ddd; padding: 4px;">Example</th></tr>
 		<tr><td style="border: 1px solid #ddd; padding: 4px;"><strong>cycletime</strong></td><td style="border: 1px solid #ddd; padding: 4px;"><code>msg.payload</code> (number)</td><td style="border: 1px solid #ddd; padding: 4px;"><code>{payload: 1000}</code></td></tr>
 		<tr><td style="border: 1px solid #ddd; padding: 4px;"><strong>trigger</strong></td><td style="border: 1px solid #ddd; padding: 4px;">Any message</td><td style="border: 1px solid #ddd; padding: 4px;"><code>{}</code></td></tr>
-		<tr><td style="border: 1px solid #ddd; padding: 4px;"><strong>setvartable</strong></td><td style="border: 1px solid #ddd; padding: 4px;"><code>msg.vartable</code> (array) OR <code>msg.payload</code> (text)</td><td style="border: 1px solid #ddd; padding: 4px;"><code>{payload: "DB1,X0.0;motor\\nDB1,INT2;temp"}</code></td></tr>
+                <tr><td style="border: 1px solid #ddd; padding: 4px;"><strong>setvartable</strong></td><td style="border: 1px solid #ddd; padding: 4px;"><code>msg.payload</code> (array or text) OR <code>msg.vartable</code> (array)</td><td style="border: 1px solid #ddd; padding: 4px;"><code>{payload: [{name: "motor", addr: "DB1,X0.0"}]}</code></td></tr>
 		<tr><td style="border: 1px solid #ddd; padding: 4px;"><strong>ssl</strong></td><td style="border: 1px solid #ddd; padding: 4px;"><code>msg.payload.id, msg.payload.index</code></td><td style="border: 1px solid #ddd; padding: 4px;"><code>{payload: {id: 17, index: 0}}</code></td></tr>
 		<tr><td style="border: 1px solid #ddd; padding: 4px;"><strong>upload-block</strong></td><td style="border: 1px solid #ddd; padding: 4px;"><code>msg.payload.type, msg.payload.number</code></td><td style="border: 1px solid #ddd; padding: 4px;"><code>{payload: {type: "DB", number: 1}}</code></td></tr>
 	</table>

--- a/red/s7.js
+++ b/red/s7.js
@@ -31,6 +31,7 @@ function equals(a, b) {
 var MIN_CYCLE_TIME = 50;
 
 var tools = require('../src/tools.js');
+var { parseVarTableInput } = require('../src/vartable.js');
 
 module.exports = function (RED) {
     "use strict";
@@ -706,42 +707,16 @@ module.exports = function (RED) {
             let func = config.function || msg.function;
             switch (func) {
                 case 'setvartable':
-                    var vartable = [];
-                    
-                    // Check if we have a vartable array (legacy mode)
-                    if (Array.isArray(msg.vartable) && msg.vartable.length) {
-                        vartable = msg.vartable;
-                    } 
-                    // Check for text parsing mode (new feature)
-                    else if (typeof msg.payload === 'string' && msg.payload.trim()) {
-                        // Parse text format: "address;name" per line
-                        var lines = msg.payload.trim().split('\n');
-                        lines.forEach(function(line) {
-                            if (line.trim()) {
-                                var parts = line.split(';');
-                                if (parts.length === 2) {
-                                    var addr = parts[0].trim();
-                                    var name = parts[1].trim();
-                                    if (addr && name) {
-                                        vartable.push({
-                                            name: name,
-                                            addr: addr
-                                        });
-                                    }
-                                }
-                            }
-                        });
-                    }
-                    
-                    // Validate we have variables to set
-                    if (!Array.isArray(vartable) || !vartable.length) {
-                        done('vartable missing or invalid. Expected either msg.vartable array or msg.payload text format "address;name" per line');
+                    var parsed = parseVarTableInput(msg);
+                    if (!parsed.vartable.length) {
+                        done(parsed.error);
                         return;
                     }
-                    
-                    node.endpoint.setVars(vartable);
+
+                    node.endpoint.setVars(parsed.vartable);
                     // Return the new list for output
-                    msg.payload = {vartable: vartable};
+                    msg.vartable = parsed.vartable;
+                    msg.payload = {vartable: parsed.vartable};
                     send(msg);
                     done();
                     break;

--- a/src/vartable.js
+++ b/src/vartable.js
@@ -1,0 +1,120 @@
+//@ts-check
+
+/**
+ * @typedef {{name: string, addr: string}} VarTableEntry
+ */
+
+/**
+ * Normalize a potential vartable entry into a consistent object.
+ * Returns null when the entry is invalid.
+ * @param {any} entry
+ * @returns {VarTableEntry|null}
+ */
+function normalizeEntry(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return null;
+    }
+
+    const name = entry.name != null ? String(entry.name).trim() : '';
+    const addr = entry.addr != null ? String(entry.addr).trim() : '';
+
+    if (!name || !addr) {
+        return null;
+    }
+
+    return { name, addr };
+}
+
+/**
+ * Normalize an array of vartable entries.
+ * Invalid entries are ignored.
+ * @param {any[]} items
+ * @returns {VarTableEntry[]}
+ */
+function normalizeArray(items) {
+    return items.reduce((acc, item) => {
+        const normalized = normalizeEntry(item);
+        if (normalized) {
+            acc.push(normalized);
+        }
+        return acc;
+    }, /** @type {VarTableEntry[]} */([]));
+}
+
+/**
+ * Parse vartable information from a text block.
+ * @param {string} text
+ * @returns {VarTableEntry[]}
+ */
+function parseText(text) {
+    return text
+        .split(/\r?\n/)
+        .map(line => line.trim())
+        .filter(Boolean)
+        .reduce((acc, line) => {
+            const separatorIndex = line.indexOf(';');
+            if (separatorIndex === -1) {
+                return acc;
+            }
+
+            const addr = line.slice(0, separatorIndex).trim();
+            const name = line.slice(separatorIndex + 1).trim();
+
+            if (addr && name) {
+                acc.push({ name, addr });
+            }
+
+            return acc;
+        }, /** @type {VarTableEntry[]} */([]));
+}
+
+/**
+ * Extract a vartable array from the incoming message.
+ * Accepts msg.vartable, msg.payload (array), msg.payload.vartable, or msg.payload text.
+ * @param {any} msg
+ * @returns {{ vartable: VarTableEntry[], error?: string }}
+ */
+function parseVarTableInput(msg) {
+    const candidates = [];
+
+    if (msg && Array.isArray(msg.vartable)) {
+        candidates.push({ source: 'msg.vartable', value: msg.vartable });
+    }
+
+    if (msg && Array.isArray(msg.payload)) {
+        candidates.push({ source: 'msg.payload', value: msg.payload });
+    }
+
+    if (msg && msg.payload && typeof msg.payload === 'object' && !Array.isArray(msg.payload) && Array.isArray(msg.payload.vartable)) {
+        candidates.push({ source: 'msg.payload.vartable', value: msg.payload.vartable });
+    }
+
+    for (const candidate of candidates) {
+        const normalized = normalizeArray(candidate.value);
+        if (normalized.length) {
+            return { vartable: normalized };
+        }
+    }
+
+    if (msg && typeof msg.payload === 'string' && msg.payload.trim()) {
+        const parsed = parseText(msg.payload.trim());
+        if (parsed.length) {
+            return { vartable: parsed };
+        }
+    }
+
+    return {
+        vartable: [],
+        error: 'vartable missing or invalid. Provide msg.vartable array, msg.payload array, msg.payload.vartable array, or msg.payload text in the format "address;name" per line.'
+    };
+}
+
+module.exports = {
+    parseVarTableInput,
+    // Exported for testing
+    _private: {
+        normalizeEntry,
+        normalizeArray,
+        parseText
+    }
+};

--- a/tests/vartable.test.js
+++ b/tests/vartable.test.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+const assert = require('assert');
+const { parseVarTableInput } = require('../src/vartable');
+
+function testPayloadArray() {
+    const msg = {
+        function: 'setvartable',
+        payload: [
+            { name: 'motor', addr: 'DB1,X0.0' },
+            { name: 'temp', addr: 'DB1,REAL2' }
+        ]
+    };
+
+    const { vartable, error } = parseVarTableInput(msg);
+    assert.ok(!error, 'Expected no error when payload array is provided');
+    assert.strictEqual(vartable.length, 2);
+    assert.deepStrictEqual(vartable[0], { name: 'motor', addr: 'DB1,X0.0' });
+}
+
+function testVartableProperty() {
+    const msg = {
+        vartable: [
+            { name: 'pressure', addr: 'DB1,REAL4' }
+        ]
+    };
+
+    const { vartable, error } = parseVarTableInput(msg);
+    assert.ok(!error, 'Expected no error when msg.vartable is provided');
+    assert.strictEqual(vartable.length, 1);
+    assert.deepStrictEqual(vartable[0], { name: 'pressure', addr: 'DB1,REAL4' });
+}
+
+function testTextPayload() {
+    const msg = {
+        payload: 'DB2,INT0;speed\r\nDB2,INT2;torque'
+    };
+
+    const { vartable, error } = parseVarTableInput(msg);
+    assert.ok(!error, 'Expected no error when payload text is provided');
+    assert.strictEqual(vartable.length, 2);
+    assert.deepStrictEqual(vartable[1], { name: 'torque', addr: 'DB2,INT2' });
+}
+
+function testInvalidPayload() {
+    const msg = { payload: 42 };
+    const { vartable, error } = parseVarTableInput(msg);
+    assert.strictEqual(vartable.length, 0);
+    assert.ok(error && error.includes('vartable missing or invalid'));
+}
+
+function run() {
+    testPayloadArray();
+    testVartableProperty();
+    testTextPayload();
+    testInvalidPayload();
+    console.log('✅ vartable parser tests passed');
+}
+
+run();


### PR DESCRIPTION
## Summary
- add a shared parser so S7 Control `setvartable` accepts arrays on `msg.payload`, `msg.vartable`, or payload text
- update inline help, README, changelog, and examples to document the restored payload array support
- add lightweight regression tests covering the new parser behaviour

## Testing
- node tests/vartable.test.js

------
https://chatgpt.com/codex/tasks/task_e_68de9378b6e8832cbbadc423035c8b01